### PR TITLE
Add margin support and safe-only classes + tailwind@3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install tailwindcss-padding-safe
 ```js
 // In your Tailwind JS config
 {
-	plugins: [require("tailwindcss-padding-safe")()]
+	plugins: [require("tailwindcss-padding-safe")]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is my first package so don't hesitate to point me on any improvement or iss
 ## Installation
 
 ```bash
-npm install tailwindcss-padding-safe
+npm install -D tailwindcss-padding-safe
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ npm install -D tailwindcss-padding-safe
 ```
 
 This plugin generates the following utilities:
++ the same with `m` prefix for margin
 
 ```css
 /* Default rules for browser without max() support same as core padding generated rules */

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ module.exports = function () {
           [`.${e(`pb-${modifier}-${suffix}`)}`]: { 'padding-bottom': `${size}` },
           [`.${e(`pl-${modifier}-${suffix}`)}`]: { 'padding-left': `${size}` },
         }),
-
         (size, modifier) => ({
           '@supports(padding: max(0px))': {
             [`.${e(`p-${modifier}-${suffix}`)}`]: { 'padding-top': `max(${size}, env(safe-area-inset-top))`, 'padding-bottom': `max(${size}, env(safe-area-inset-bottom))` , 'padding-left': `max(${size}, env(safe-area-inset-left))` , 'padding-right': `max(${size}, env(safe-area-inset-right))` },
@@ -36,11 +35,57 @@ module.exports = function () {
             [`.${e(`pl-${modifier}-${suffix}`)}`]: { 'padding-left': `max(${size}, env(safe-area-inset-left))` },
           }
         }),
+
+        (size, modifier) => (onlySupportsRules ? null : {
+          [`.${e(`m-${modifier}-${suffix}`)}`]: { 'margin': `${size}` },
+        }),
+        (size, modifier) => (onlySupportsRules ? null : {
+          [`.${e(`my-${modifier}-${suffix}`)}`]: { 'margin-top': `${size}`, 'margin-bottom': `${size}` },
+          [`.${e(`mx-${modifier}-${suffix}`)}`]: { 'margin-left': `${size}`, 'margin-right': `${size}` },
+        }),
+        (size, modifier) => (onlySupportsRules ? null : {
+          [`.${e(`mt-${modifier}-${suffix}`)}`]: { 'margin-top': `${size}` },
+          [`.${e(`mr-${modifier}-${suffix}`)}`]: { 'margin-right': `${size}` },
+          [`.${e(`mb-${modifier}-${suffix}`)}`]: { 'margin-bottom': `${size}` },
+          [`.${e(`ml-${modifier}-${suffix}`)}`]: { 'margin-left': `${size}` },
+        }),
+        (size, modifier) => ({
+          '@supports(margin: max(0px))': {
+            [`.${e(`m-${modifier}-${suffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))`, 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` , 'margin-left': `max(${size}, env(safe-area-inset-left))` , 'margin-right': `max(${size}, env(safe-area-inset-right))` },
+
+            [`.${e(`my-${modifier}-${suffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))`, 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` },
+            [`.${e(`mx-${modifier}-${suffix}`)}`]: { 'margin-left': `max(${size}, env(safe-area-inset-left))`, 'margin-right': `max(${size}, env(safe-area-inset-right))` },
+
+            [`.${e(`mt-${modifier}-${suffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))` },
+            [`.${e(`mr-${modifier}-${suffix}`)}`]: { 'margin-right': `max(${size}, env(safe-area-inset-right))` },
+            [`.${e(`mb-${modifier}-${suffix}`)}`]: { 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` },
+            [`.${e(`ml-${modifier}-${suffix}`)}`]: { 'margin-left': `max(${size}, env(safe-area-inset-left))` },
+          }
+        })
       ]
 
       const utilities = _.flatMap(generators, generator => {
         return _.flatMap(paddings, generator)
-      })
+      });
+      
+      utilities.push({
+        '.p-safe': { 'padding-top': 'env(safe-area-inset-top)', 'padding-bottom': 'env(safe-area-inset-bottom)', 'padding-left': 'env(safe-area-inset-left)', 'padding-right': 'env(safe-area-inset-right)' },
+        '.py-safe': { 'padding-top': 'env(safe-area-inset-top)', 'padding-bottom': 'env(safe-area-inset-bottom)' },
+        '.px-safe': { 'padding-left': 'env(safe-area-inset-left)', 'padding-right': 'env(safe-area-inset-right)' },
+        '.pt-safe': { 'padding-top': 'env(safe-area-inset-top)' },
+        '.pr-safe': { 'padding-right': 'env(safe-area-inset-right)' },
+        '.pb-safe': { 'padding-bottom': 'env(safe-area-inset-bottom)'},
+        '.pl-safe': { 'padding-left': 'env(safe-area-inset-left)' },
+      });
+      utilities.push({
+        '.m-safe': { 'margin-top': 'env(safe-area-inset-top)', 'margin-bottom': 'env(safe-area-inset-bottom)', 'margin-left': 'env(safe-area-inset-left)', 'margin-right': 'env(safe-area-inset-right)' },
+        '.my-safe': { 'margin-top': 'env(safe-area-inset-top)', 'margin-bottom': 'env(safe-area-inset-bottom)' },
+        '.mx-safe': { 'margin-left': 'env(safe-area-inset-left)', 'margin-right': 'env(safe-area-inset-right)' },
+        '.mt-safe': { 'margin-top': 'env(safe-area-inset-top)' },
+        '.mr-safe': { 'margin-right': 'env(safe-area-inset-right)' },
+        '.mb-safe': { 'margin-bottom': 'env(safe-area-inset-bottom)'},
+        '.ml-safe': { 'margin-left': 'env(safe-area-inset-left)' },
+      });
 
       addUtilities(utilities, variants)
   }

--- a/index.js
+++ b/index.js
@@ -1,109 +1,107 @@
+const plugin = require('tailwindcss/plugin');
 const { flatMap } = require('lodash');
 
-module.exports = function () {
-  return function({ addUtilities, e, config }) {
+module.exports = plugin(function({ addUtilities, e, config }) {
+  // Paddings
+  const paddings = config('theme.paddingSafe.padding', config('theme.padding', {}));
+  const paddingVariants = config('variants.paddingSafe', config('variants.padding', {}));
+  const paddingSuffix = config('theme.paddingSafe.suffix', 'safe');
+  const paddingOnlySupportsRules = config('theme.paddingSafe.onlySupportsRules', false);
 
-    // Paddings
-    const paddings = config('theme.paddingSafe.padding', config('theme.padding', {}));
-    const paddingVariants = config('variants.paddingSafe', config('variants.padding', {}));
-    const paddingSuffix = config('theme.paddingSafe.suffix', 'safe');
-    const paddingOnlySupportsRules = config('theme.paddingSafe.onlySupportsRules', false);
+  const paddingGenerators = [
+    (size, modifier) => (paddingOnlySupportsRules ? null : {
+      [`.${e(`p-${modifier}-${paddingSuffix}`)}`]: { 'padding': `${size}` },
+    }),
+    (size, modifier) => (paddingOnlySupportsRules ? null : {
+      [`.${e(`py-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `${size}`, 'padding-bottom': `${size}` },
+      [`.${e(`px-${modifier}-${paddingSuffix}`)}`]: { 'padding-left': `${size}`, 'padding-right': `${size}` },
+    }),
+    (size, modifier) => (paddingOnlySupportsRules ? null : {
+      [`.${e(`pt-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `${size}` },
+      [`.${e(`pr-${modifier}-${paddingSuffix}`)}`]: { 'padding-right': `${size}` },
+      [`.${e(`pb-${modifier}-${paddingSuffix}`)}`]: { 'padding-bottom': `${size}` },
+      [`.${e(`pl-${modifier}-${paddingSuffix}`)}`]: { 'padding-left': `${size}` },
+    }),
+    (size, modifier) => ({
+      '@supports(padding: max(0px))': {
+        [`.${e(`p-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `max(${size}, env(safe-area-inset-top))`, 'padding-bottom': `max(${size}, env(safe-area-inset-bottom))` , 'padding-left': `max(${size}, env(safe-area-inset-left))` , 'padding-right': `max(${size}, env(safe-area-inset-right))` },
 
-    const paddingGenerators = [
-      (size, modifier) => (paddingOnlySupportsRules ? null : {
-        [`.${e(`p-${modifier}-${paddingSuffix}`)}`]: { 'padding': `${size}` },
-      }),
-      (size, modifier) => (paddingOnlySupportsRules ? null : {
-        [`.${e(`py-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `${size}`, 'padding-bottom': `${size}` },
-        [`.${e(`px-${modifier}-${paddingSuffix}`)}`]: { 'padding-left': `${size}`, 'padding-right': `${size}` },
-      }),
-      (size, modifier) => (paddingOnlySupportsRules ? null : {
-        [`.${e(`pt-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `${size}` },
-        [`.${e(`pr-${modifier}-${paddingSuffix}`)}`]: { 'padding-right': `${size}` },
-        [`.${e(`pb-${modifier}-${paddingSuffix}`)}`]: { 'padding-bottom': `${size}` },
-        [`.${e(`pl-${modifier}-${paddingSuffix}`)}`]: { 'padding-left': `${size}` },
-      }),
-      (size, modifier) => ({
-        '@supports(padding: max(0px))': {
-          [`.${e(`p-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `max(${size}, env(safe-area-inset-top))`, 'padding-bottom': `max(${size}, env(safe-area-inset-bottom))` , 'padding-left': `max(${size}, env(safe-area-inset-left))` , 'padding-right': `max(${size}, env(safe-area-inset-right))` },
+        [`.${e(`py-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `max(${size}, env(safe-area-inset-top))`, 'padding-bottom': `max(${size}, env(safe-area-inset-bottom))` },
+        [`.${e(`px-${modifier}-${paddingSuffix}`)}`]: { 'padding-left': `max(${size}, env(safe-area-inset-left))`, 'padding-right': `max(${size}, env(safe-area-inset-right))` },
 
-          [`.${e(`py-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `max(${size}, env(safe-area-inset-top))`, 'padding-bottom': `max(${size}, env(safe-area-inset-bottom))` },
-          [`.${e(`px-${modifier}-${paddingSuffix}`)}`]: { 'padding-left': `max(${size}, env(safe-area-inset-left))`, 'padding-right': `max(${size}, env(safe-area-inset-right))` },
+        [`.${e(`pt-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `max(${size}, env(safe-area-inset-top))` },
+        [`.${e(`pr-${modifier}-${paddingSuffix}`)}`]: { 'padding-right': `max(${size}, env(safe-area-inset-right))` },
+        [`.${e(`pb-${modifier}-${paddingSuffix}`)}`]: { 'padding-bottom': `max(${size}, env(safe-area-inset-bottom))` },
+        [`.${e(`pl-${modifier}-${paddingSuffix}`)}`]: { 'padding-left': `max(${size}, env(safe-area-inset-left))` },
+      }
+    })
+  ];
+  
+  const paddingUtilities = flatMap(paddingGenerators, generator => {
+    return flatMap(paddings, generator)
+  });
+  
+  addUtilities(paddingUtilities, paddingVariants);
+  
+  // Margins
+  const margins = config('theme.marginSafe.margin', config('theme.margin', {}));
+  const marginVariants = config('variants.marginSafe', config('variants.margin', {}));
+  const marginSuffix = config('theme.marginSafe.suffix', 'safe');
+  const marginOnlySupportsRules = config('theme.marginSafe.onlySupportsRules', false);
+  
+  const marginGenerators = [
+    (size, modifier) => (marginOnlySupportsRules ? null : {
+      [`.${e(`m-${modifier}-${marginSuffix}`)}`]: { 'margin': `${size}` },
+    }),
+    (size, modifier) => (marginOnlySupportsRules ? null : {
+      [`.${e(`my-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `${size}`, 'margin-bottom': `${size}` },
+      [`.${e(`mx-${modifier}-${marginSuffix}`)}`]: { 'margin-left': `${size}`, 'margin-right': `${size}` },
+    }),
+    (size, modifier) => (marginOnlySupportsRules ? null : {
+      [`.${e(`mt-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `${size}` },
+      [`.${e(`mr-${modifier}-${marginSuffix}`)}`]: { 'margin-right': `${size}` },
+      [`.${e(`mb-${modifier}-${marginSuffix}`)}`]: { 'margin-bottom': `${size}` },
+      [`.${e(`ml-${modifier}-${marginSuffix}`)}`]: { 'margin-left': `${size}` },
+    }),
+    (size, modifier) => ({
+      '@supports(margin: max(0px))': {
+        [`.${e(`m-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))`, 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` , 'margin-left': `max(${size}, env(safe-area-inset-left))` , 'margin-right': `max(${size}, env(safe-area-inset-right))` },
 
-          [`.${e(`pt-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `max(${size}, env(safe-area-inset-top))` },
-          [`.${e(`pr-${modifier}-${paddingSuffix}`)}`]: { 'padding-right': `max(${size}, env(safe-area-inset-right))` },
-          [`.${e(`pb-${modifier}-${paddingSuffix}`)}`]: { 'padding-bottom': `max(${size}, env(safe-area-inset-bottom))` },
-          [`.${e(`pl-${modifier}-${paddingSuffix}`)}`]: { 'padding-left': `max(${size}, env(safe-area-inset-left))` },
-        }
-      })
-    ];
-    
-    const paddingUtilities = flatMap(paddingGenerators, generator => {
-      return flatMap(paddings, generator)
-    });
-    
-    addUtilities(paddingUtilities, paddingVariants);
-    
-    // Margins
-    const margins = config('theme.marginSafe.margin', config('theme.margin', {}));
-    const marginVariants = config('variants.marginSafe', config('variants.margin', {}));
-    const marginSuffix = config('theme.marginSafe.suffix', 'safe');
-    const marginOnlySupportsRules = config('theme.marginSafe.onlySupportsRules', false);
-    
-    const marginGenerators = [
-      (size, modifier) => (marginOnlySupportsRules ? null : {
-        [`.${e(`m-${modifier}-${marginSuffix}`)}`]: { 'margin': `${size}` },
-      }),
-      (size, modifier) => (marginOnlySupportsRules ? null : {
-        [`.${e(`my-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `${size}`, 'margin-bottom': `${size}` },
-        [`.${e(`mx-${modifier}-${marginSuffix}`)}`]: { 'margin-left': `${size}`, 'margin-right': `${size}` },
-      }),
-      (size, modifier) => (marginOnlySupportsRules ? null : {
-        [`.${e(`mt-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `${size}` },
-        [`.${e(`mr-${modifier}-${marginSuffix}`)}`]: { 'margin-right': `${size}` },
-        [`.${e(`mb-${modifier}-${marginSuffix}`)}`]: { 'margin-bottom': `${size}` },
-        [`.${e(`ml-${modifier}-${marginSuffix}`)}`]: { 'margin-left': `${size}` },
-      }),
-      (size, modifier) => ({
-        '@supports(margin: max(0px))': {
-          [`.${e(`m-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))`, 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` , 'margin-left': `max(${size}, env(safe-area-inset-left))` , 'margin-right': `max(${size}, env(safe-area-inset-right))` },
+        [`.${e(`my-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))`, 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` },
+        [`.${e(`mx-${modifier}-${marginSuffix}`)}`]: { 'margin-left': `max(${size}, env(safe-area-inset-left))`, 'margin-right': `max(${size}, env(safe-area-inset-right))` },
 
-          [`.${e(`my-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))`, 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` },
-          [`.${e(`mx-${modifier}-${marginSuffix}`)}`]: { 'margin-left': `max(${size}, env(safe-area-inset-left))`, 'margin-right': `max(${size}, env(safe-area-inset-right))` },
+        [`.${e(`mt-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))` },
+        [`.${e(`mr-${modifier}-${marginSuffix}`)}`]: { 'margin-right': `max(${size}, env(safe-area-inset-right))` },
+        [`.${e(`mb-${modifier}-${marginSuffix}`)}`]: { 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` },
+        [`.${e(`ml-${modifier}-${marginSuffix}`)}`]: { 'margin-left': `max(${size}, env(safe-area-inset-left))` },
+      }
+    })
+  ]
+  
+  const marginUtilities = flatMap(marginGenerators, generator => {
+    return flatMap(margins, generator)
+  });
+  
+  addUtilities(marginUtilities, marginVariants);
 
-          [`.${e(`mt-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))` },
-          [`.${e(`mr-${modifier}-${marginSuffix}`)}`]: { 'margin-right': `max(${size}, env(safe-area-inset-right))` },
-          [`.${e(`mb-${modifier}-${marginSuffix}`)}`]: { 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` },
-          [`.${e(`ml-${modifier}-${marginSuffix}`)}`]: { 'margin-left': `max(${size}, env(safe-area-inset-left))` },
-        }
-      })
-    ]
-    
-    const marginUtilities = flatMap(marginGenerators, generator => {
-      return flatMap(margins, generator)
-    });
-    
-    addUtilities(marginUtilities, marginVariants);
+  // Safe area only classes
+  const utilities = [{
+    '.p-safe': { 'padding-top': 'env(safe-area-inset-top)', 'padding-bottom': 'env(safe-area-inset-bottom)', 'padding-left': 'env(safe-area-inset-left)', 'padding-right': 'env(safe-area-inset-right)' },
+    '.py-safe': { 'padding-top': 'env(safe-area-inset-top)', 'padding-bottom': 'env(safe-area-inset-bottom)' },
+    '.px-safe': { 'padding-left': 'env(safe-area-inset-left)', 'padding-right': 'env(safe-area-inset-right)' },
+    '.pt-safe': { 'padding-top': 'env(safe-area-inset-top)' },
+    '.pr-safe': { 'padding-right': 'env(safe-area-inset-right)' },
+    '.pb-safe': { 'padding-bottom': 'env(safe-area-inset-bottom)'},
+    '.pl-safe': { 'padding-left': 'env(safe-area-inset-left)' },
+  }, {
+    '.m-safe': { 'margin-top': 'env(safe-area-inset-top)', 'margin-bottom': 'env(safe-area-inset-bottom)', 'margin-left': 'env(safe-area-inset-left)', 'margin-right': 'env(safe-area-inset-right)' },
+    '.my-safe': { 'margin-top': 'env(safe-area-inset-top)', 'margin-bottom': 'env(safe-area-inset-bottom)' },
+    '.mx-safe': { 'margin-left': 'env(safe-area-inset-left)', 'margin-right': 'env(safe-area-inset-right)' },
+    '.mt-safe': { 'margin-top': 'env(safe-area-inset-top)' },
+    '.mr-safe': { 'margin-right': 'env(safe-area-inset-right)' },
+    '.mb-safe': { 'margin-bottom': 'env(safe-area-inset-bottom)'},
+    '.ml-safe': { 'margin-left': 'env(safe-area-inset-left)' },
+  }];
 
-    // Safe area only classes
-    const utilities = [{
-      '.p-safe': { 'padding-top': 'env(safe-area-inset-top)', 'padding-bottom': 'env(safe-area-inset-bottom)', 'padding-left': 'env(safe-area-inset-left)', 'padding-right': 'env(safe-area-inset-right)' },
-      '.py-safe': { 'padding-top': 'env(safe-area-inset-top)', 'padding-bottom': 'env(safe-area-inset-bottom)' },
-      '.px-safe': { 'padding-left': 'env(safe-area-inset-left)', 'padding-right': 'env(safe-area-inset-right)' },
-      '.pt-safe': { 'padding-top': 'env(safe-area-inset-top)' },
-      '.pr-safe': { 'padding-right': 'env(safe-area-inset-right)' },
-      '.pb-safe': { 'padding-bottom': 'env(safe-area-inset-bottom)'},
-      '.pl-safe': { 'padding-left': 'env(safe-area-inset-left)' },
-    }, {
-      '.m-safe': { 'margin-top': 'env(safe-area-inset-top)', 'margin-bottom': 'env(safe-area-inset-bottom)', 'margin-left': 'env(safe-area-inset-left)', 'margin-right': 'env(safe-area-inset-right)' },
-      '.my-safe': { 'margin-top': 'env(safe-area-inset-top)', 'margin-bottom': 'env(safe-area-inset-bottom)' },
-      '.mx-safe': { 'margin-left': 'env(safe-area-inset-left)', 'margin-right': 'env(safe-area-inset-right)' },
-      '.mt-safe': { 'margin-top': 'env(safe-area-inset-top)' },
-      '.mr-safe': { 'margin-right': 'env(safe-area-inset-right)' },
-      '.mb-safe': { 'margin-bottom': 'env(safe-area-inset-bottom)'},
-      '.ml-safe': { 'margin-left': 'env(safe-area-inset-left)' },
-    }];
-
-    addUtilities(utilities);
-  }
-}
+  addUtilities(utilities);
+})

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const _ = require('lodash')
+const { flatMap } = require('lodash');
 
 module.exports = function () {
   return function({ addUtilities, e, config }) {

--- a/index.js
+++ b/index.js
@@ -3,90 +3,107 @@ const _ = require('lodash')
 module.exports = function () {
   return function({ addUtilities, e, config }) {
 
-      const paddings = config('theme.paddingSafe.padding',config('theme.padding',{}))
-      const variants = config('variants.paddingSafe',config('variants.padding',{}))
-      const suffix = config('theme.paddingSafe.suffix','safe')
-      const onlySupportsRules = config('theme.paddingSafe.onlySupportsRules',false)
+    // Paddings
+    const paddings = config('theme.paddingSafe.padding', config('theme.padding', {}));
+    const paddingVariants = config('variants.paddingSafe', config('variants.padding', {}));
+    const paddingSuffix = config('theme.paddingSafe.suffix', 'safe');
+    const paddingOnlySupportsRules = config('theme.paddingSafe.onlySupportsRules', false);
 
-      const generators = [
-        (size, modifier) => (onlySupportsRules ? null : {
-          [`.${e(`p-${modifier}-${suffix}`)}`]: { 'padding': `${size}` },
-        }),
-        (size, modifier) => (onlySupportsRules ? null : {
-          [`.${e(`py-${modifier}-${suffix}`)}`]: { 'padding-top': `${size}`, 'padding-bottom': `${size}` },
-          [`.${e(`px-${modifier}-${suffix}`)}`]: { 'padding-left': `${size}`, 'padding-right': `${size}` },
-        }),
-        (size, modifier) => (onlySupportsRules ? null : {
-          [`.${e(`pt-${modifier}-${suffix}`)}`]: { 'padding-top': `${size}` },
-          [`.${e(`pr-${modifier}-${suffix}`)}`]: { 'padding-right': `${size}` },
-          [`.${e(`pb-${modifier}-${suffix}`)}`]: { 'padding-bottom': `${size}` },
-          [`.${e(`pl-${modifier}-${suffix}`)}`]: { 'padding-left': `${size}` },
-        }),
-        (size, modifier) => ({
-          '@supports(padding: max(0px))': {
-            [`.${e(`p-${modifier}-${suffix}`)}`]: { 'padding-top': `max(${size}, env(safe-area-inset-top))`, 'padding-bottom': `max(${size}, env(safe-area-inset-bottom))` , 'padding-left': `max(${size}, env(safe-area-inset-left))` , 'padding-right': `max(${size}, env(safe-area-inset-right))` },
+    const paddingGenerators = [
+      (size, modifier) => (paddingOnlySupportsRules ? null : {
+        [`.${e(`p-${modifier}-${paddingSuffix}`)}`]: { 'padding': `${size}` },
+      }),
+      (size, modifier) => (paddingOnlySupportsRules ? null : {
+        [`.${e(`py-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `${size}`, 'padding-bottom': `${size}` },
+        [`.${e(`px-${modifier}-${paddingSuffix}`)}`]: { 'padding-left': `${size}`, 'padding-right': `${size}` },
+      }),
+      (size, modifier) => (paddingOnlySupportsRules ? null : {
+        [`.${e(`pt-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `${size}` },
+        [`.${e(`pr-${modifier}-${paddingSuffix}`)}`]: { 'padding-right': `${size}` },
+        [`.${e(`pb-${modifier}-${paddingSuffix}`)}`]: { 'padding-bottom': `${size}` },
+        [`.${e(`pl-${modifier}-${paddingSuffix}`)}`]: { 'padding-left': `${size}` },
+      }),
+      (size, modifier) => ({
+        '@supports(padding: max(0px))': {
+          [`.${e(`p-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `max(${size}, env(safe-area-inset-top))`, 'padding-bottom': `max(${size}, env(safe-area-inset-bottom))` , 'padding-left': `max(${size}, env(safe-area-inset-left))` , 'padding-right': `max(${size}, env(safe-area-inset-right))` },
 
-            [`.${e(`py-${modifier}-${suffix}`)}`]: { 'padding-top': `max(${size}, env(safe-area-inset-top))`, 'padding-bottom': `max(${size}, env(safe-area-inset-bottom))` },
-            [`.${e(`px-${modifier}-${suffix}`)}`]: { 'padding-left': `max(${size}, env(safe-area-inset-left))`, 'padding-right': `max(${size}, env(safe-area-inset-right))` },
+          [`.${e(`py-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `max(${size}, env(safe-area-inset-top))`, 'padding-bottom': `max(${size}, env(safe-area-inset-bottom))` },
+          [`.${e(`px-${modifier}-${paddingSuffix}`)}`]: { 'padding-left': `max(${size}, env(safe-area-inset-left))`, 'padding-right': `max(${size}, env(safe-area-inset-right))` },
 
-            [`.${e(`pt-${modifier}-${suffix}`)}`]: { 'padding-top': `max(${size}, env(safe-area-inset-top))` },
-            [`.${e(`pr-${modifier}-${suffix}`)}`]: { 'padding-right': `max(${size}, env(safe-area-inset-right))` },
-            [`.${e(`pb-${modifier}-${suffix}`)}`]: { 'padding-bottom': `max(${size}, env(safe-area-inset-bottom))` },
-            [`.${e(`pl-${modifier}-${suffix}`)}`]: { 'padding-left': `max(${size}, env(safe-area-inset-left))` },
-          }
-        }),
+          [`.${e(`pt-${modifier}-${paddingSuffix}`)}`]: { 'padding-top': `max(${size}, env(safe-area-inset-top))` },
+          [`.${e(`pr-${modifier}-${paddingSuffix}`)}`]: { 'padding-right': `max(${size}, env(safe-area-inset-right))` },
+          [`.${e(`pb-${modifier}-${paddingSuffix}`)}`]: { 'padding-bottom': `max(${size}, env(safe-area-inset-bottom))` },
+          [`.${e(`pl-${modifier}-${paddingSuffix}`)}`]: { 'padding-left': `max(${size}, env(safe-area-inset-left))` },
+        }
+      })
+    ];
+    
+    const paddingUtilities = flatMap(paddingGenerators, generator => {
+      return flatMap(paddings, generator)
+    });
+    
+    addUtilities(paddingUtilities, paddingVariants);
+    
+    // Margins
+    const margins = config('theme.marginSafe.margin', config('theme.margin', {}));
+    const marginVariants = config('variants.marginSafe', config('variants.margin', {}));
+    const marginSuffix = config('theme.marginSafe.suffix', 'safe');
+    const marginOnlySupportsRules = config('theme.marginSafe.onlySupportsRules', false);
+    
+    const marginGenerators = [
+      (size, modifier) => (marginOnlySupportsRules ? null : {
+        [`.${e(`m-${modifier}-${marginSuffix}`)}`]: { 'margin': `${size}` },
+      }),
+      (size, modifier) => (marginOnlySupportsRules ? null : {
+        [`.${e(`my-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `${size}`, 'margin-bottom': `${size}` },
+        [`.${e(`mx-${modifier}-${marginSuffix}`)}`]: { 'margin-left': `${size}`, 'margin-right': `${size}` },
+      }),
+      (size, modifier) => (marginOnlySupportsRules ? null : {
+        [`.${e(`mt-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `${size}` },
+        [`.${e(`mr-${modifier}-${marginSuffix}`)}`]: { 'margin-right': `${size}` },
+        [`.${e(`mb-${modifier}-${marginSuffix}`)}`]: { 'margin-bottom': `${size}` },
+        [`.${e(`ml-${modifier}-${marginSuffix}`)}`]: { 'margin-left': `${size}` },
+      }),
+      (size, modifier) => ({
+        '@supports(margin: max(0px))': {
+          [`.${e(`m-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))`, 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` , 'margin-left': `max(${size}, env(safe-area-inset-left))` , 'margin-right': `max(${size}, env(safe-area-inset-right))` },
 
-        (size, modifier) => (onlySupportsRules ? null : {
-          [`.${e(`m-${modifier}-${suffix}`)}`]: { 'margin': `${size}` },
-        }),
-        (size, modifier) => (onlySupportsRules ? null : {
-          [`.${e(`my-${modifier}-${suffix}`)}`]: { 'margin-top': `${size}`, 'margin-bottom': `${size}` },
-          [`.${e(`mx-${modifier}-${suffix}`)}`]: { 'margin-left': `${size}`, 'margin-right': `${size}` },
-        }),
-        (size, modifier) => (onlySupportsRules ? null : {
-          [`.${e(`mt-${modifier}-${suffix}`)}`]: { 'margin-top': `${size}` },
-          [`.${e(`mr-${modifier}-${suffix}`)}`]: { 'margin-right': `${size}` },
-          [`.${e(`mb-${modifier}-${suffix}`)}`]: { 'margin-bottom': `${size}` },
-          [`.${e(`ml-${modifier}-${suffix}`)}`]: { 'margin-left': `${size}` },
-        }),
-        (size, modifier) => ({
-          '@supports(margin: max(0px))': {
-            [`.${e(`m-${modifier}-${suffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))`, 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` , 'margin-left': `max(${size}, env(safe-area-inset-left))` , 'margin-right': `max(${size}, env(safe-area-inset-right))` },
+          [`.${e(`my-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))`, 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` },
+          [`.${e(`mx-${modifier}-${marginSuffix}`)}`]: { 'margin-left': `max(${size}, env(safe-area-inset-left))`, 'margin-right': `max(${size}, env(safe-area-inset-right))` },
 
-            [`.${e(`my-${modifier}-${suffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))`, 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` },
-            [`.${e(`mx-${modifier}-${suffix}`)}`]: { 'margin-left': `max(${size}, env(safe-area-inset-left))`, 'margin-right': `max(${size}, env(safe-area-inset-right))` },
+          [`.${e(`mt-${modifier}-${marginSuffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))` },
+          [`.${e(`mr-${modifier}-${marginSuffix}`)}`]: { 'margin-right': `max(${size}, env(safe-area-inset-right))` },
+          [`.${e(`mb-${modifier}-${marginSuffix}`)}`]: { 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` },
+          [`.${e(`ml-${modifier}-${marginSuffix}`)}`]: { 'margin-left': `max(${size}, env(safe-area-inset-left))` },
+        }
+      })
+    ]
+    
+    const marginUtilities = flatMap(marginGenerators, generator => {
+      return flatMap(margins, generator)
+    });
+    
+    addUtilities(marginUtilities, marginVariants);
 
-            [`.${e(`mt-${modifier}-${suffix}`)}`]: { 'margin-top': `max(${size}, env(safe-area-inset-top))` },
-            [`.${e(`mr-${modifier}-${suffix}`)}`]: { 'margin-right': `max(${size}, env(safe-area-inset-right))` },
-            [`.${e(`mb-${modifier}-${suffix}`)}`]: { 'margin-bottom': `max(${size}, env(safe-area-inset-bottom))` },
-            [`.${e(`ml-${modifier}-${suffix}`)}`]: { 'margin-left': `max(${size}, env(safe-area-inset-left))` },
-          }
-        })
-      ]
+    // Safe area only classes
+    const utilities = [{
+      '.p-safe': { 'padding-top': 'env(safe-area-inset-top)', 'padding-bottom': 'env(safe-area-inset-bottom)', 'padding-left': 'env(safe-area-inset-left)', 'padding-right': 'env(safe-area-inset-right)' },
+      '.py-safe': { 'padding-top': 'env(safe-area-inset-top)', 'padding-bottom': 'env(safe-area-inset-bottom)' },
+      '.px-safe': { 'padding-left': 'env(safe-area-inset-left)', 'padding-right': 'env(safe-area-inset-right)' },
+      '.pt-safe': { 'padding-top': 'env(safe-area-inset-top)' },
+      '.pr-safe': { 'padding-right': 'env(safe-area-inset-right)' },
+      '.pb-safe': { 'padding-bottom': 'env(safe-area-inset-bottom)'},
+      '.pl-safe': { 'padding-left': 'env(safe-area-inset-left)' },
+    }, {
+      '.m-safe': { 'margin-top': 'env(safe-area-inset-top)', 'margin-bottom': 'env(safe-area-inset-bottom)', 'margin-left': 'env(safe-area-inset-left)', 'margin-right': 'env(safe-area-inset-right)' },
+      '.my-safe': { 'margin-top': 'env(safe-area-inset-top)', 'margin-bottom': 'env(safe-area-inset-bottom)' },
+      '.mx-safe': { 'margin-left': 'env(safe-area-inset-left)', 'margin-right': 'env(safe-area-inset-right)' },
+      '.mt-safe': { 'margin-top': 'env(safe-area-inset-top)' },
+      '.mr-safe': { 'margin-right': 'env(safe-area-inset-right)' },
+      '.mb-safe': { 'margin-bottom': 'env(safe-area-inset-bottom)'},
+      '.ml-safe': { 'margin-left': 'env(safe-area-inset-left)' },
+    }];
 
-      const utilities = _.flatMap(generators, generator => {
-        return _.flatMap(paddings, generator)
-      });
-      
-      utilities.push({
-        '.p-safe': { 'padding-top': 'env(safe-area-inset-top)', 'padding-bottom': 'env(safe-area-inset-bottom)', 'padding-left': 'env(safe-area-inset-left)', 'padding-right': 'env(safe-area-inset-right)' },
-        '.py-safe': { 'padding-top': 'env(safe-area-inset-top)', 'padding-bottom': 'env(safe-area-inset-bottom)' },
-        '.px-safe': { 'padding-left': 'env(safe-area-inset-left)', 'padding-right': 'env(safe-area-inset-right)' },
-        '.pt-safe': { 'padding-top': 'env(safe-area-inset-top)' },
-        '.pr-safe': { 'padding-right': 'env(safe-area-inset-right)' },
-        '.pb-safe': { 'padding-bottom': 'env(safe-area-inset-bottom)'},
-        '.pl-safe': { 'padding-left': 'env(safe-area-inset-left)' },
-      });
-      utilities.push({
-        '.m-safe': { 'margin-top': 'env(safe-area-inset-top)', 'margin-bottom': 'env(safe-area-inset-bottom)', 'margin-left': 'env(safe-area-inset-left)', 'margin-right': 'env(safe-area-inset-right)' },
-        '.my-safe': { 'margin-top': 'env(safe-area-inset-top)', 'margin-bottom': 'env(safe-area-inset-bottom)' },
-        '.mx-safe': { 'margin-left': 'env(safe-area-inset-left)', 'margin-right': 'env(safe-area-inset-right)' },
-        '.mt-safe': { 'margin-top': 'env(safe-area-inset-top)' },
-        '.mr-safe': { 'margin-right': 'env(safe-area-inset-right)' },
-        '.mb-safe': { 'margin-bottom': 'env(safe-area-inset-bottom)'},
-        '.ml-safe': { 'margin-left': 'env(safe-area-inset-left)' },
-      });
-
-      addUtilities(utilities, variants)
+    addUtilities(utilities);
   }
 }


### PR DESCRIPTION
Based upon the name of the package this is a bit out of scope.
But I needed this for my project and used your code as a starting point.

I added all the same classes for margin like the ones that have been used in padding.
And I added classes that contain the safe area env only